### PR TITLE
fix reflective caustics

### DIFF
--- a/Target_Surface/SurfaceModel.cpp
+++ b/Target_Surface/SurfaceModel.cpp
@@ -534,10 +534,10 @@ void Model::fresnelMapping() {
         }
 
         if (REFLECTIVE_CAUSTICS) {
-            glm::vec3 norm = glm::normalize(screenDirections[i] + incidentLight);
+            glm::vec3 norm = glm::normalize(glm::normalize(screenDirections[i]) + glm::normalize(incidentLight));
             desiredNormals.push_back(norm);
         } else {
-            glm::vec3 norm = glm::normalize(glm::normalize(screenDirections[i]) - glm::normalize(incidentLight) * refraction) * -1.0f;
+            glm::vec3 norm = glm::normalize(glm::normalize(screenDirections[i]) + glm::normalize(incidentLight) * refraction) * -1.0f;
             desiredNormals.push_back(norm);
         }
     }

--- a/Target_Surface/global.h
+++ b/Target_Surface/global.h
@@ -44,11 +44,11 @@
 #define REFLECTIVE_CAUSTICS false 
 
 #if (REFLECTIVE_CAUSTICS == false)
-    #define INCIDENT_RAY_X 1.0f 
+    #define INCIDENT_RAY_X -1.0f 
     #define INCIDENT_RAY_Y 0.0f
     #define INCIDENT_RAY_Z 0.0f
 #else
-    #define INCIDENT_RAY_X -1.0f 
+    #define INCIDENT_RAY_X 1.0f 
     #define INCIDENT_RAY_Y 0.0f
     #define INCIDENT_RAY_Z 0.0f
 #endif


### PR DESCRIPTION
I noticed you had a commit ec420b7 (added support for reflective caustics), but this feature has not been enabled.

I tried it today and found that there might be some bugs.

I have fixed them.

Here's a rendered image from a 100x100 mesh test.

![reflectivecaustic](https://github.com/user-attachments/assets/56063eba-7744-4cf8-983f-c866583981ec)

Thanks for your hard work on this project!