### PR TITLE
Non-square support for Target_Surface

### DIFF
--- a/Target_Surface/SurfaceMesh.cpp
+++ b/Target_Surface/SurfaceMesh.cpp
@@ -203,12 +203,20 @@ void Mesh::createFrontFaceMatrix()
 {
     frontFaceMatrix.clear();
 
-    int rows = (int) (sqrt(faceVerticesEdge.size()) + 0.5);
-    int cols = rows;
+    // int rows = (int) (sqrt(faceVerticesEdge.size()) + 0.5);
+    // int cols = rows;
 
-    std::cout << "rows = " << rows << std::endl;
+    // temporary solution, assuming stepZ and stepY are equal
+    int rows = (int) (sqrt(faceVerticesEdge.size() * maxZ / maxY) + 0.5);
+    int cols = (int) (sqrt(faceVerticesEdge.size() * maxY / maxZ) + 0.5);
 
-    double step = (2*maxY) / (rows-1);
+    std::cout << "rows = " << rows << ", cols = " << cols << std::endl;
+
+    double stepY = (2*maxY) / (cols-1);
+    double stepZ = (2*maxZ) / (rows-1);
+
+    std::cout << "stepZ = " << stepZ << ", stepY = " << stepY << std::endl; // should be equal
+    // std::cout << "2*maxZ/stepZ = rows-1 = " << 2*maxZ/stepZ << ", 2*maxY/stepY = cols-1 = " << 2*maxY/stepY << std::endl;
 
     frontFaceMatrix.resize(rows);
     vertexRowMap.resize(faceVerticesEdge.size());
@@ -227,8 +235,8 @@ void Mesh::createFrontFaceMatrix()
     {
         glm::vec3 * pos = &faceVerticesEdge[i]->Position;
 
-        int col = (int) (((pos->y + maxY) / step) + 0.5);
-        int row = (int) (((pos->z + maxZ) / step) + 0.5);
+        int col = (int) (((pos->y + maxY) / stepY) + 0.5);
+        int row = (int) (((pos->z + maxZ) / stepZ) + 0.5);
 
         frontFaceMatrix[row][col] = i;
 

--- a/Target_Surface/SurfaceModel.cpp
+++ b/Target_Surface/SurfaceModel.cpp
@@ -534,10 +534,10 @@ void Model::fresnelMapping() {
         }
 
         if (REFLECTIVE_CAUSTICS) {
-            glm::vec3 norm = glm::normalize(screenDirections[i] + incidentLight);
+            glm::vec3 norm = glm::normalize(glm::normalize(screenDirections[i]) + glm::normalize(incidentLight));
             desiredNormals.push_back(norm);
         } else {
-            glm::vec3 norm = glm::normalize(glm::normalize(screenDirections[i]) - glm::normalize(incidentLight) * refraction) * -1.0f;
+            glm::vec3 norm = glm::normalize(glm::normalize(screenDirections[i]) + glm::normalize(incidentLight) * refraction) * -1.0f;
             desiredNormals.push_back(norm);
         }
     }

--- a/Target_Surface/global.h
+++ b/Target_Surface/global.h
@@ -44,11 +44,11 @@
 #define REFLECTIVE_CAUSTICS false 
 
 #if (REFLECTIVE_CAUSTICS == false)
-    #define INCIDENT_RAY_X 1.0f 
+    #define INCIDENT_RAY_X -1.0f 
     #define INCIDENT_RAY_Y 0.0f
     #define INCIDENT_RAY_Z 0.0f
 #else
-    #define INCIDENT_RAY_X -1.0f 
+    #define INCIDENT_RAY_X 1.0f 
     #define INCIDENT_RAY_Y 0.0f
     #define INCIDENT_RAY_Z 0.0f
 #endif


### PR DESCRIPTION
fix #6 

This is just a temporary solution. It requires each cell from the input model to be a square. This means if the model's aspect ratio is 5:7 (as shown in the image), the subdivision ratio should also be 5:7 (500:700 in the example below).

example: 
![fugue-render](https://github.com/user-attachments/assets/5d8b9672-534e-48e1-8cd9-02d4397f90e1)

